### PR TITLE
Small improvements to Stream API

### DIFF
--- a/repository/RediStick-Stream-Objects-Tests.package/RsStreamConsumerGroupPollerTest.class/instance/testGroupPollWithDelete.st
+++ b/repository/RediStick-Stream-Objects-Tests.package/RsStreamConsumerGroupPollerTest.class/instance/testGroupPollWithDelete.st
@@ -1,0 +1,43 @@
+tests
+testGroupPollWithDelete
+	| strm consumerGroup entries1 consumer1 poller1 entries2 consumer2 poller2 deletedIds leftIds |
+	strm := self newStreamNamed: 'testGroupPollWithDelete'.
+	strm trimTo: 0.
+	self assert: strm length equals: 0.
+	consumerGroup := strm consumerGroupNamed: 'group1'.
+	
+	entries1 := OrderedCollection new.
+	consumer1 := consumerGroup consumerNamed: 'consumer1'.
+	poller1 := consumer1 poller.
+	poller1 onReceive: [ :each | entries1 add: each. (Delay forMilliseconds: 5) wait].
+	poller1 start.
+	consumer2 := consumerGroup consumerNamed: 'consumer2'.
+	poller2 := consumer2 poller.
+	poller2 shouldDeleteEntryAfterAcceptance: true.
+	entries2 := OrderedCollection new.
+	poller2 onReceive: [ :each | entries2 add: each. (Delay forMilliseconds: 5) wait].
+	poller2 start.
+	
+	1 to: 10 do: [ :idx |
+		strm nextPut: (('idx:', idx asString) -> idx).
+	].
+	(Delay forMilliseconds: 100) wait.
+	[consumerGroup summaryPendingList isEmpty] whileFalse: [ (Delay forMilliseconds: 100) wait].
+	
+	poller1 stop.
+	poller2 stop.
+	
+	self assert: entries1 size + entries2 size equals: 10.
+	self assert: (entries1 intersection: entries2) size equals: 0.
+	consumerGroup destroy.
+	
+	deletedIds := entries2 collect: [:each | each id].
+	leftIds := strm contents collect: [:each | each id].
+	self assert: deletedIds isEmpty equals: false.
+	self assert: deletedIds size + leftIds size equals: 10.
+	self assert: (leftIds includesAnyOf: deletedIds) equals: false.
+	
+	strm trimTo: 0.
+	self assert: strm length equals: 0.
+	
+	

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsAtMost.after.on..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsAtMost.after.on..st
@@ -1,6 +1,6 @@
 reading
 pendingsAtMost: count after: latestMessageId on: consumerName
-	^ self wrapAsAcceptableEntries: ( self endpoint
+	^ self wrapAsAcceptableEntries: (self endpoint
 		  xGroupRead: self streamName
 		  id: latestMessageId
 		  group: self name

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsNoAckAfter.on..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsNoAckAfter.on..st
@@ -1,6 +1,6 @@
 reading
 pendingsNoAckAfter: latestMessageId on: consumerName
-	^ self wrapAsAcceptableEntries: ( self endpoint
+	^ self wrapAsAcceptableEntries: (self endpoint
 		  xGroupRead: self streamName
 		  id: latestMessageId
 		  group: self name

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsNoAckAtMost.after.on..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroup.class/instance/pendingsNoAckAtMost.after.on..st
@@ -1,6 +1,6 @@
 reading
 pendingsNoAckAtMost: count after: latestMessageId on: consumerName
-	^ self wrapAsAcceptableEntries: ( self endpoint
+	^ self wrapAsAcceptableEntries: (self endpoint
 		  xGroupRead: self streamName
 		  id: latestMessageId
 		  group: self name

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/handleReceived..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/handleReceived..st
@@ -1,0 +1,4 @@
+handling
+handleReceived: receivedEntry
+	super handleReceived: receivedEntry.
+	self shouldDeleteEntryAfterAcceptance ifTrue: [ self stream deleteAt: receivedEntry id ]

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/shouldDeleteEntryAfterAcceptance..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/shouldDeleteEntryAfterAcceptance..st
@@ -1,0 +1,3 @@
+accessing
+shouldDeleteEntryAfterAcceptance: aBoolean
+	shouldDeleteEntryAfterAcceptance := aBoolean 

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/shouldDeleteEntryAfterAcceptance.st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/instance/shouldDeleteEntryAfterAcceptance.st
@@ -1,0 +1,3 @@
+accessing
+shouldDeleteEntryAfterAcceptance
+	^ shouldDeleteEntryAfterAcceptance ifNil: [ shouldDeleteEntryAfterAcceptance := false ]

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/properties.json
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupBasePoller.class/properties.json
@@ -6,7 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"consumer"
+		"consumer",
+		"shouldDeleteEntryAfterAcceptance"
 	],
 	"name" : "RsStreamConsumerGroupBasePoller",
 	"type" : "normal"

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/autoClaimEvery..st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/autoClaimEvery..st
@@ -1,0 +1,4 @@
+claiming
+autoClaimEvery: aDulation
+	self updateLastClaimTimestamp.
+	self autoClaimIfTrue: [ :c | (DateAndTime now - c lastClaimTimestamp) >= aDulation ]

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/claimPending.st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/claimPending.st
@@ -1,3 +1,4 @@
 private
 claimPending
-	self consumer autoClaimIdleMoreThan: self claimMinIdleMilliseconds
+	self consumer autoClaimIdleMoreThan: self claimMinIdleMilliseconds.
+	self updateLastClaimTimestamp

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/lastClaimTimestamp.st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/lastClaimTimestamp.st
@@ -1,0 +1,3 @@
+accessing
+lastClaimTimestamp
+	^ lastClaimTimestamp

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/updateLastClaimTimestamp.st
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/instance/updateLastClaimTimestamp.st
@@ -1,0 +1,3 @@
+private
+updateLastClaimTimestamp
+	lastClaimTimestamp := DateAndTime now

--- a/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/properties.json
+++ b/repository/RediStick-Stream-Objects.package/RsStreamConsumerGroupPoller.class/properties.json
@@ -7,7 +7,8 @@
 	"classvars" : [ ],
 	"instvars" : [
 		"shouldAutoClaimBlock",
-		"claimMinIdleMilliseconds"
+		"claimMinIdleMilliseconds",
+		"lastClaimTimestamp"
 	],
 	"name" : "RsStreamConsumerGroupPoller",
 	"type" : "normal"


### PR DESCRIPTION
- Added RsStreamConsumerGroupPoller>>autoClaimEvery: for claiming with a specific interval
- Added RsStreamConsumerGroupBasePoller>>shouldDeleteEntryAfterAcceptance setting to enable deletion of accepted entries.