### PR TITLE
ci: replace redis-stack CI service with redis 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       redis:
-        image: redis/redis-stack:latest
+        image: redis:8
         ports:
           - "6379:6379"
           - "8001:8001"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Please read [Stream.md](./doc/Stream.md).
 
 ### Using Search
 
-RediStick supports [RediSearch](https://redis.io/docs/stack/search/) - a full-text search extension for Redis.
+RediStick supports [RediSearch](https://redis.io/docs/latest/develop/ai/search-and-query/) - a full-text search extension for Redis.
 
 Please read [Search.md](./doc/Search.md).
 

--- a/doc/Search.md
+++ b/doc/Search.md
@@ -1,16 +1,16 @@
 # Working with RediSearch in RediStick
 
-[RediStick](https://github.com/mumez/RediStick) supports [RediSearch](https://redis.io/docs/stack/search/) - a full-text search extension for Redis.
+[RediStick](https://github.com/mumez/RediStick) supports [RediSearch](https://redis.io/docs/latest/develop/ai/search-and-query/) - a full-text search extension for Redis.
 
 ## Installation
 
 ### Setting up RediSearch
 
-RediSearch is a component of the [Redis Stack](https://redis.io/docs/stack/) and it is not included in Redis by default.
-The easiest way to start a RediSearch enabled Redis is to use the [official docker image](https://hub.docker.com/r/redis/redis-stack).
+From Redis 8 onward, RediSearch capabilities are available in the standard Redis image.
+The easiest way to start a RediSearch-enabled server is to use the [official Redis image](https://hub.docker.com/_/redis).
 
 ```bash
-docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 -v /local-data/:/data redis/redis-stack:latest
+docker run -d --name redis8 -p 6379:6379 -v /local-data/:/data redis:8
 ```
 
 ### Installing RediStick Search packages
@@ -38,7 +38,7 @@ Metacello new
 ### Creating an index
 
 ```Smalltalk
-stick := RsRediStick targetUrl: 'stack://localhost'.
+stick := RsRediStick targetUrl: 'sync://localhost'.
 stick connect.
 
 indexName := 'smalltalk-index'.
@@ -116,7 +116,7 @@ resultSet results collect: [:each | each content]. "an OrderedCollection(a Dicti
 Smalltalk' 'tags'->'Commercial,Seaside,AppeX' ))"
 ```
 
-For more query patterns, you can see the [query syntax](https://redis.io/docs/stack/search/reference/query_syntax/) reference.
+For more query patterns, see the [RediSearch query documentation](https://redis.io/docs/latest/develop/ai/search-and-query/).
 
 ### Dropping an index
 
@@ -133,4 +133,4 @@ endpoint ftListIndexes.
 
 ## ToDo
 
-- [ ] [Aggregations](https://redis.io/docs/stack/search/reference/aggregations/) Support
+- [ ] [Aggregations](https://redis.io/docs/latest/develop/ai/search-and-query/) Support


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update GitHub Actions Redis service image from `redis/redis-stack:latest` to `redis:8`
- update documentation to remove remaining Redis Stack references
  - `README.md` RediSearch link updated
  - `doc/Search.md` installation text/docker command/link examples updated for Redis 8

## Verification
- `rg "redis-stack|Redis Stack|/stack/|stack://" /workspace/README.md` -> no matches
- `rg "redis-stack|Redis Stack|/stack/|stack://" /workspace/doc` -> no matches
- local `smalltalkci` execution is unavailable in this cloud environment (`smalltalkci: command not found`), so test pass/fail is confirmed via GitHub Actions CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee1bf3a-83dd-46b2-b672-0ac976a65f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee1bf3a-83dd-46b2-b672-0ac976a65f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

