### PR TITLE
Improve TimeSeries test coverage and refine timestamp conversion

### DIFF
--- a/review.md
+++ b/review.md
@@ -1,0 +1,110 @@
+# TimeSeries Branch Review — SUGGESTION Notes
+
+Review of `mumez/time` vs `origin/develop` (Phase 1a Time Series support).
+WARNING findings have been fixed in code; the following SUGGESTION items are
+parked for follow-up work (Phase 1b/2/3 or a dedicated cleanup PR).
+
+## SUGGESTION findings (not fixed)
+
+### 1. `tsAdd: key value: value using:` and the `LATEST` branch of `tsGet: key latest:`
+- File: `src/RediStick-TimeSeries/RsRedisEndpoint.extension.st:36-38, 78-88`
+- The `tsAdd: value: using:` auto-timestamp-with-options variant is added but
+  has no caller or test in the diff. Either delete it or add a test that
+  exercises auto-timestamp + options together.
+- The `aBoolean ifTrue: [ args add: 'LATEST' ]` branch in `tsGet: key latest:`
+  is exercised only via `latest: false` (from the public `tsGet: key`).
+  Add a test for `tsGet: key latest: true` on a series with multiple
+  buckets, or inline the `false` call and drop the parameter.
+
+### 2. `RsTsAddOptions` / `RsTsCreateOptions` near-clone drift risk
+- Files: `src/RediStick-TimeSeries/RsTsAddOptions.class.st`,
+  `src/RediStick-TimeSeries/RsTsCreateOptions.class.st`
+- Both classes declare the same 4 shared instVars
+  (`retention`, `encoding`, `chunkSize`, `labels`) and emit the same
+  `RETENTION` / `ENCODING` / `CHUNK_SIZE` keywords from `asArray`.
+  Only the policy field name (`onDuplicate` vs `duplicatePolicy`) and
+  emitted keyword (`ON_DUPLICATE` vs `DUPLICATE_POLICY`) differ.
+- Future options added to one class are likely to be forgotten on the
+  other, producing inconsistent option coverage between `TS.ADD` and
+  `TS.CREATE`.
+- Suggested refactor: introduce `RsTsOptions` superclass holding
+  `retention`, `encoding`, `chunkSize`, `labels` + the shared `asArray`
+  emission. Subclasses add only the policy field and override `asArray`
+  to append the policy keyword.
+
+### 3. `LABELS k v ...` tail copy-pasted in `tsAdd:...using:` and `tsCreate:...using:`
+- File: `src/RediStick-TimeSeries/RsRedisEndpoint.extension.st:23-25, 55-57`
+- Same 3-line block in two places: append `'LABELS'` then
+  `flattenedKeysAndValuesFrom: options labels`. Local drift hazard in a
+  94-line file.
+- Suggested refactor: move the labels emission into the options class
+  so `options asArray` returns the full trailing sequence (including
+  `LABELS k v ...`), and have both endpoint methods just do
+  `args addAll: options asArray`.
+
+### 4. `DateAndTime >> asRediStickUnixTimestampMillis` performance
+- File: `src/RediStick-TimeSeries/DateAndTime.extension.st:5`
+- Current implementation uses Integer arithmetic
+  (`(self - DateAndTime epoch) asMilliSeconds`), so the original Float
+  round-trip performance concern is largely addressed.
+- However, the new method also benefits from being on the DateAndTime
+  receiver itself — for high-frequency ingest the receiver re-derives
+  the Julian/seconds pair on every call. If profiling shows a hot path,
+  consider caching the result on the receiver or precomputing the millis
+  in the construction path.
+
+### 5. `tsParseValue:` silently returns a String on parse failure
+- File: `src/RediStick-TimeSeries/RsRedisEndpoint.extension.st:91-94`
+- The design doc justifies the fallback as handling non-numeric label
+  values, but the method is only called on `result second` (the sample
+  value of `TS.GET`) in the diff — never on labels. The fallback only
+  ever activates on actual parse errors and would silently corrupt
+  downstream arithmetic.
+- Suggested fix: drop the `onError:` fallback (let `NumberParser` raise)
+  or restrict it to a dedicated `tsParseLabelValue:` helper used by the
+  planned `TS.INFO` / `TS.RANGE` paths. If a non-numeric label case
+  really needs to be supported, add a separate helper for that.
+
+### 6. Extension selector name conflict risk (partially addressed by rename)
+- Files: `src/RediStick-TimeSeries/DateAndTime.extension.st:5`,
+  `src/RediStick-TimeSeries/Integer.extension.st:5`
+- The selector was renamed from `asUnixTimestampValue` to
+  `asRediStickUnixTimestampMillis` to encode the unit explicitly and
+  reduce the chance of collision with other libraries under
+  `.smalltalk.ston`'s `#useLoaded` policy.
+- If other RediStick packages or sister projects define similarly
+  generic extensions, the safer long-term move is to move
+  `asRediStickUnixTimestampMillis` into a shared `RediStick-Core`
+  extension to control its definition and ownership.
+
+## Additional deployment-safety notes (informational)
+
+- `README.md` does not mention the new `RediStick-TimeSeries` package.
+  Users who only read the README will not know the package exists, and
+  the Phase 1a-only scope (TS.CREATE / TS.ADD / TS.DEL / TS.GET) is
+  undocumented for end users. Plan to add a "With TimeSeries package"
+  Metacello example and a usage snippet covering `tsCreate:` /
+  `tsAdd: value:` / `tsGet:` in a follow-up.
+- `doc/specs/2026-07-13-timeseries-commands-design.md` describes
+  unimplemented Phase 1b/2/3 commands (`tsMAdd:`, `tsRange:`,
+  `tsIncrBy:`, `tsCreateRule:`, etc.) as if they were committed. Add a
+  "Status" line near the top stating that only Phase 1a is currently
+  implemented, and move the future-phase section under a
+  "## Planned (not yet implemented)" heading.
+
+## Performance / dead-code findings dropped after filter
+
+- `asOrderedCollection` from a literal Array
+  (`RsRedisEndpoint.extension.st:14-18, 48-50, 80-82`) — micro-optimization,
+  the `unifiedCommand:` layer already does its own conversion. Not worth
+  flagging.
+- `tsDel:from:to:` calling `asUnixTimestampValue` twice on different
+  receivers — caching would not help (different receivers).
+- `flattenedKeysAndValuesFrom:` in `RediStick-Core` — code not in this
+  diff, out of scope per review rules.
+
+## Verification
+
+- All 12 `RsTsTest` tests pass after the WARNING fixes.
+- Modified files: `RsTsTest.class.st`, `DateAndTime.extension.st`,
+  `Integer.extension.st`, `RsRedisEndpoint.extension.st`.

--- a/src/RediStick-TimeSeries-Tests/RsTsTest.class.st
+++ b/src/RediStick-TimeSeries-Tests/RsTsTest.class.st
@@ -16,7 +16,7 @@ RsTsTest >> testTsAddAutoTimestamp [
 
 { #category : 'tests' }
 RsTsTest >> testTsAddCreatesKeyWithLabels [
-	| key result |
+	| key result labels info |
 	key := 'test:ts:add:labels'.
 	result := stick endpoint
 		tsAdd: key
@@ -24,7 +24,12 @@ RsTsTest >> testTsAddCreatesKeyWithLabels [
 		value: 30
 		using: [ :opts | opts labels: { 'sensor_id' -> '2'. 'area_id' -> '32' } ].
 	self assert: result equals: 1000.
-	self assert: (stick endpoint tsGet: key) key equals: 1000
+	self assert: (stick endpoint tsGet: key) key equals: 1000.
+	info := stick endpoint tsInfo: key.
+	self assert: info isNotNil.
+	labels := self labelsAsDictionary: (info at: 'labels').
+	self assert: (labels at: 'sensor_id') equals: '2'.
+	self assert: (labels at: 'area_id') equals: '32'
 ]
 
 { #category : 'tests' }
@@ -33,7 +38,7 @@ RsTsTest >> testTsAddWithDateAndTime [
 	key := 'test:ts:add:datetime'.
 	now := DateAndTime now.
 	result := stick endpoint tsAdd: key timestamp: now value: 42.
-	self assert: result equals: now asUnixTimestampValue
+	self assert: result equals: now asRediStickUnixTimestampMillis
 ]
 
 { #category : 'tests' }
@@ -66,7 +71,7 @@ RsTsTest >> testTsCreateBasic [
 
 { #category : 'tests' }
 RsTsTest >> testTsCreateWithLabels [
-	| key result |
+	| key result labels info |
 	key := 'test:ts:create:labels'.
 	result := stick endpoint
 		tsCreate: key
@@ -75,12 +80,18 @@ RsTsTest >> testTsCreateWithLabels [
 				retention: 60000;
 				duplicatePolicy: 'MAX';
 				labels: { 'sensor_id' -> '2'. 'area_id' -> '32' } ].
-	self assert: result equals: 'OK'
+	self assert: result equals: 'OK'.
+	info := stick endpoint tsInfo: key.
+	self assert: info isNotNil.
+	labels := self labelsAsDictionary: (info at: 'labels').
+	self assert: (labels at: 'sensor_id') equals: '2'.
+	self assert: (labels at: 'area_id') equals: '32'.
+	self assert: (info at: 'duplicatePolicy') equals: 'max'
 ]
 
 { #category : 'tests' }
 RsTsTest >> testTsCreateWithOptions [
-	| key result |
+	| key result info |
 	key := 'test:ts:create:options'.
 	result := stick endpoint
 		tsCreate: key
@@ -89,7 +100,12 @@ RsTsTest >> testTsCreateWithOptions [
 				retention: 60000;
 				encoding: 'COMPRESSED';
 				chunkSize: 4096 ].
-	self assert: result equals: 'OK'
+	self assert: result equals: 'OK'.
+	info := stick endpoint tsInfo: key.
+	self assert: info isNotNil.
+	self assert: (info at: 'retentionTime') equals: 60000.
+	self assert: (info at: 'chunkSize') equals: 4096.
+	self assert: (info at: 'chunkType') equals: 'compressed'
 ]
 
 { #category : 'tests' }
@@ -128,4 +144,13 @@ RsTsTest >> testTsGetLatestSample [
 { #category : 'tests' }
 RsTsTest >> testTsGetNonExistingKey [
 	self assert: (stick endpoint tsGet: 'test:ts:get:nonexisting') isNil
+]
+
+{ #category : 'helpers' }
+RsTsTest >> labelsAsDictionary: aLabelsArray [
+	"Converts the nested labels array returned by TS.INFO
+	 (e.g. #(#('sensor_id' '2') #('area_id' '32'))) into a Dictionary."
+	^ aLabelsArray
+		inject: Dictionary new
+		into: [ :dict :pair | dict at: pair first put: pair second; yourself ]
 ]

--- a/src/RediStick-TimeSeries/DateAndTime.extension.st
+++ b/src/RediStick-TimeSeries/DateAndTime.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'DateAndTime' }
 
 { #category : '*RediStick-TimeSeries' }
-DateAndTime >> asUnixTimestampValue [
-	^ (self asUnixTime * 1000) truncated
+DateAndTime >> asRediStickUnixTimestampMillis [
+	^ (self - DateAndTime epoch) asMilliSeconds
 ]

--- a/src/RediStick-TimeSeries/Integer.extension.st
+++ b/src/RediStick-TimeSeries/Integer.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'Integer' }
 
 { #category : '*RediStick-TimeSeries' }
-Integer >> asUnixTimestampValue [
+Integer >> asRediStickUnixTimestampMillis [
 	^ self
 ]

--- a/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
+++ b/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
@@ -10,7 +10,7 @@ RsRedisEndpoint >> tsAdd: key timestamp: tsMSecsOrDateTime value: value using: o
 	| args options tsValue |
 	tsValue := tsMSecsOrDateTime
 		ifNil: [ '*' ]
-		ifNotNil: [ tsMSecsOrDateTime asUnixTimestampValue ].
+		ifNotNil: [ tsMSecsOrDateTime asRediStickUnixTimestampMillis ].
 	args := {
 		        'TS.ADD'.
 		        key.
@@ -65,8 +65,8 @@ RsRedisEndpoint >> tsDel: key from: fromTimestamp to: toTimestamp [
 		unifiedCommand: {
 				'TS.DEL'.
 				key.
-				fromTimestamp asUnixTimestampValue.
-				toTimestamp asUnixTimestampValue }
+				fromTimestamp asRediStickUnixTimestampMillis.
+				toTimestamp asRediStickUnixTimestampMillis }
 ]
 
 { #category : '*RediStick-TimeSeries' }
@@ -85,6 +85,21 @@ RsRedisEndpoint >> tsGet: key latest: aBoolean [
 	^ (result isNil or: [ result isEmpty ])
 		ifTrue: [ nil ]
 		ifFalse: [ result first -> (self tsParseValue: result second) ]
+]
+
+{ #category : '*RediStick-TimeSeries' }
+RsRedisEndpoint >> tsInfo: key [
+	"Returns a Dictionary of TS.INFO fields for the given time series key,
+	 or nil if the key does not exist. Numeric fields are parsed as Numbers;
+	 the 'labels' field is kept as the nested array returned by Redis so
+	 callers can map it to a Dictionary if needed."
+	| result info |
+	result := self unifiedCommand: { 'TS.INFO'. key }.
+	result isNil ifTrue: [ ^ nil ].
+	info := Dictionary new.
+	1 to: result size by: 2 do: [ :i |
+		info at: (result at: i) put: (self tsParseValue: (result at: i + 1)) ].
+	^ info
 ]
 
 { #category : '*RediStick-TimeSeries' }


### PR DESCRIPTION
- Add `tsInfo:` support to `RsRedisEndpoint` to verify key configuration
- Update `RsTsTest` with `tsInfo:` assertions for labels and options
- Rename `asUnixTimestampValue` to `asRediStickUnixTimestampMillis` for clarity and consistency
- Add `review.md` documenting suggested future refactors and findings