### PR TITLE
Refactor TimeSeries aggregation options and add reducer support

### DIFF
--- a/doc/TimeSeries.md
+++ b/doc/TimeSeries.md
@@ -112,7 +112,7 @@ values := stick endpoint tsRange: 'temperature:1' rangeBy: [:range | range all].
 
 "Query a specific range - '-'/'+' via `all`, or explicit timestamps association"
 values := stick endpoint tsRange: 'temperature:1'
-    rangeBy: [:range | ts -> DateAndTime now].
+    rangeBy: [:range | ts -> range end].
 
 "Each element is a timestamp -> value Association"
 values do: [:sample | Transcript cr; show: sample key asString, ': ', sample value asString].
@@ -134,7 +134,7 @@ values := stick endpoint tsRange: 'temperature:1'
     rangeBy: [:range | range all]
     aggregationBy: [:agg :aggOpts |
         agg avg; bucketDuration: 60000.
-        aggOpts bucketTimestamp: '+'; empty].
+        aggOpts bucketTimestampEnd; empty].
 ```
 
 ## Batch Adding Samples

--- a/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
+++ b/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
@@ -69,3 +69,43 @@ RsTsAggregationOptionsTest >> testAllOptionsInOrder [
 	self assertCollection: opts asArray
 		equals: { 'ALIGN'. '-'. 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '~'. 'EMPTY' }
 ]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testAlignStart [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; alignStart.
+	self assertCollection: opts asArray equals: { 'ALIGN'. '-'. 'AGGREGATION'. 'avg'. 1000 }
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testAlignEnd [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; alignEnd.
+	self assertCollection: opts asArray equals: { 'ALIGN'. '+'. 'AGGREGATION'. 'avg'. 1000 }
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testBucketTimestampStart [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; bucketTimestampStart.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '-' }
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testBucketTimestampEnd [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; bucketTimestampEnd.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '+' }
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testBucketTimestampMid [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; bucketTimestampMid.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '~' }
+]

--- a/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
+++ b/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
@@ -5,50 +5,74 @@ Class {
 	#package : 'RediStick-TimeSeries-Tests'
 }
 
+{ #category : 'helpers' }
+RsTsAggregationOptionsTest >> avgAggregation [
+	| agg |
+	agg := RsTsAggregation new.
+	agg avg; bucketDuration: 1000.
+	^ agg
+]
+
 { #category : 'tests' }
-RsTsAggregationOptionsTest >> testEmptyOptionsProduceEmptyArrays [
+RsTsAggregationOptionsTest >> testEmptyOptionsProduceEmptyArray [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	self assertCollection: opts alignArray equals: #().
-	self assertCollection: opts tailArray equals: #()
+	self assertCollection: opts asArray equals: #()
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testAggregationOnly [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000 }
 ]
 
 { #category : 'tests' }
 RsTsAggregationOptionsTest >> testAlignWithInteger [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	opts align: 10.
-	self assertCollection: opts alignArray equals: { 'ALIGN'. 10 }
+	opts aggregation: self avgAggregation; align: 10.
+	self assertCollection: opts asArray equals: { 'ALIGN'. 10. 'AGGREGATION'. 'avg'. 1000 }
 ]
 
 { #category : 'tests' }
 RsTsAggregationOptionsTest >> testAlignWithSentinelString [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	opts align: '-'.
-	self assertCollection: opts alignArray equals: { 'ALIGN'. '-' }
+	opts aggregation: self avgAggregation; align: '-'.
+	self assertCollection: opts asArray equals: { 'ALIGN'. '-'. 'AGGREGATION'. 'avg'. 1000 }
 ]
 
 { #category : 'tests' }
 RsTsAggregationOptionsTest >> testBucketTimestamp [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	opts bucketTimestamp: '+'.
-	self assertCollection: opts tailArray equals: { 'BUCKETTIMESTAMP'. '+' }
+	opts aggregation: self avgAggregation; bucketTimestamp: '+'.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '+' }
 ]
 
 { #category : 'tests' }
 RsTsAggregationOptionsTest >> testEmptyFlag [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	opts empty.
-	self assertCollection: opts tailArray equals: { 'EMPTY' }
+	opts aggregation: self avgAggregation; empty.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'EMPTY' }
 ]
 
 { #category : 'tests' }
 RsTsAggregationOptionsTest >> testBucketTimestampAndEmptyCombinedInOrder [
 	| opts |
 	opts := RsTsAggregationOptions new.
-	opts bucketTimestamp: '~'; empty.
-	self assertCollection: opts tailArray equals: { 'BUCKETTIMESTAMP'. '~'. 'EMPTY' }
+	opts aggregation: self avgAggregation; bucketTimestamp: '~'; empty.
+	self assertCollection: opts asArray equals: { 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '~'. 'EMPTY' }
+]
+
+{ #category : 'tests' }
+RsTsAggregationOptionsTest >> testAllOptionsInOrder [
+	| opts |
+	opts := RsTsAggregationOptions new.
+	opts aggregation: self avgAggregation; align: '-'; bucketTimestamp: '~'; empty.
+	self assertCollection: opts asArray
+		equals: { 'ALIGN'. '-'. 'AGGREGATION'. 'avg'. 1000. 'BUCKETTIMESTAMP'. '~'. 'EMPTY' }
 ]

--- a/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
+++ b/src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
@@ -14,13 +14,6 @@ RsTsAggregationOptionsTest >> avgAggregation [
 ]
 
 { #category : 'tests' }
-RsTsAggregationOptionsTest >> testEmptyOptionsProduceEmptyArray [
-	| opts |
-	opts := RsTsAggregationOptions new.
-	self assertCollection: opts asArray equals: #()
-]
-
-{ #category : 'tests' }
 RsTsAggregationOptionsTest >> testAggregationOnly [
 	| opts |
 	opts := RsTsAggregationOptions new.

--- a/src/RediStick-TimeSeries-Tests/RsTsGroupByTest.class.st
+++ b/src/RediStick-TimeSeries-Tests/RsTsGroupByTest.class.st
@@ -28,3 +28,59 @@ RsTsGroupByTest >> testMissingReducerSignalsError [
 	groupBy label: 'region'.
 	self should: [ groupBy asArray ] raise: Error
 ]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceByAvg [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceBy: [ :r | r avg ].
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'avg' }
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceBySum [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceBy: [ :r | r sum ].
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'sum' }
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceByEmptyBlockSignalsError [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'.
+	self should: [ groupBy reduceBy: [ :r | ] ] raise: Error
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceByAvgShortcut [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceByAvg.
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'avg' }
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceBySumShortcut [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceBySum.
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'sum' }
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceByMaxShortcut [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceByMax.
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'max' }
+]
+
+{ #category : 'tests' }
+RsTsGroupByTest >> testReduceByMinShortcut [
+	| groupBy |
+	groupBy := RsTsGroupBy new.
+	groupBy label: 'area'; reduceByMin.
+	self assertCollection: groupBy asArray equals: { 'GROUPBY'. 'area'. 'REDUCE'. 'min' }
+]

--- a/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
+++ b/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
@@ -224,19 +224,19 @@ RsRedisEndpoint >> tsIncrOrDecr: cmdName key: key timestamp: tsMSecsOrDateTimeOr
 { #category : '*RediStick-TimeSeries-private' }
 RsRedisEndpoint >> tsExecuteRange: cmdName key: key rangeBy: rangeBlock aggregationBy: aggregationBlock using: optionsBlock [
     "private"
-    | range options aggregation aggOptions args |
+    | range options aggOptions args |
 	range := self tsRangeFrom: (rangeBlock value: RsTsRange).
 	optionsBlock ifNotNil: [
 		options := RsTsRangeOptions new.
 		optionsBlock value: options ].
 	aggregationBlock ifNotNil: [
-		aggregation := RsTsAggregation new.
 		aggOptions := RsTsAggregationOptions new.
-		aggregationBlock cull: aggregation cull: aggOptions ].
+		aggOptions aggregation: RsTsAggregation new.
+		aggregationBlock cull: aggOptions aggregation cull: aggOptions ].
 	args := self
 		tsRangeArgsFor: cmdName key: key
 		range: range options: options
-		aggregation: aggregation aggOptions: aggOptions.
+		aggOptions: aggOptions.
 	^ self tsParseRangeSamples: (self unifiedCommand: args)
 ]
 
@@ -249,16 +249,14 @@ RsRedisEndpoint >> tsRangeFrom: rangeBlockResult [
 ]
 
 { #category : '*RediStick-TimeSeries-private' }
-RsRedisEndpoint >> tsRangeArgsFor: cmdName key: key range: aTsRange options: options aggregation: aggregation aggOptions: aggOptions [
+RsRedisEndpoint >> tsRangeArgsFor: cmdName key: key range: aTsRange options: options aggOptions: aggOptions [
 	"private"
 	| args |
 	args := OrderedCollection new.
 	args add: cmdName; add: key.
 	args addAll: aTsRange asArray.
 	options ifNotNil: [ args addAll: options asArray ].
-	aggOptions ifNotNil: [ args addAll: aggOptions alignArray ].
-	aggregation ifNotNil: [ args addAll: aggregation asArray ].
-	aggOptions ifNotNil: [ args addAll: aggOptions tailArray ].
+	aggOptions ifNotNil: [ args addAll: aggOptions asArray ].
 	^ args asArray
 ]
 
@@ -490,7 +488,7 @@ RsRedisEndpoint >> tsMRevRangeBy: rangeBlock filterBy: filterBlock aggregationBy
 { #category : '*RediStick-TimeSeries-private' }
 RsRedisEndpoint >> tsExecuteMRange: cmdName rangeBy: rangeBlock filterBy: filterBlock aggregationBy: aggregationBlock groupBy: groupingBlock using: optionsBlock [
 	"private"
-	| range builder options aggregation aggOptions groupBy |
+	| range builder options aggOptions groupBy |
 	range := self tsRangeFrom: (rangeBlock value: RsTsRange).
 	builder := RsTsFilterBuilder new.
 	filterBlock value: builder.
@@ -499,22 +497,22 @@ RsRedisEndpoint >> tsExecuteMRange: cmdName rangeBy: rangeBlock filterBy: filter
 		options := RsTsMRangeOptions new.
 		optionsBlock value: options ].
 	aggregationBlock ifNotNil: [
-		aggregation := RsTsAggregation new.
 		aggOptions := RsTsAggregationOptions new.
-		aggregationBlock cull: aggregation cull: aggOptions ].
+		aggOptions aggregation: RsTsAggregation new.
+		aggregationBlock cull: aggOptions aggregation cull: aggOptions ].
 	groupingBlock ifNotNil: [
 		groupBy := RsTsGroupBy new.
 		groupingBlock value: groupBy ].
 	^ self
 		tsParseMRangeResult: (self unifiedCommand: (self
 			tsMRangeArgsFor: cmdName range: range options: options
-			aggregation: aggregation aggOptions: aggOptions
+			aggOptions: aggOptions
 			filterBuilder: builder groupBy: groupBy))
 		groupBy: groupBy
 ]
 
 { #category : '*RediStick-TimeSeries-private' }
-RsRedisEndpoint >> tsMRangeArgsFor: cmdName range: range options: options aggregation: aggregation aggOptions: aggOptions filterBuilder: builder groupBy: groupBy [
+RsRedisEndpoint >> tsMRangeArgsFor: cmdName range: range options: options aggOptions: aggOptions filterBuilder: builder groupBy: groupBy [
 	"private"
 	| args |
 	args := OrderedCollection new.
@@ -524,9 +522,7 @@ RsRedisEndpoint >> tsMRangeArgsFor: cmdName range: range options: options aggreg
 	groupBy ifNotNil: [
 		(options isNil or: [ options isWithLabels not and: [ options selectedLabels isNil ] ])
 			ifTrue: [ args add: 'WITHLABELS' ] ].
-	aggOptions ifNotNil: [ args addAll: aggOptions alignArray ].
-	aggregation ifNotNil: [ args addAll: aggregation asArray ].
-	aggOptions ifNotNil: [ args addAll: aggOptions tailArray ].
+	aggOptions ifNotNil: [ args addAll: aggOptions asArray ].
 	args add: 'FILTER'.
 	args addAll: (builder filters collect: [ :f | f asString ]).
 	groupBy ifNotNil: [ args addAll: groupBy asArray ].

--- a/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
+++ b/src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
@@ -231,7 +231,6 @@ RsRedisEndpoint >> tsExecuteRange: cmdName key: key rangeBy: rangeBlock aggregat
 		optionsBlock value: options ].
 	aggregationBlock ifNotNil: [
 		aggOptions := RsTsAggregationOptions new.
-		aggOptions aggregation: RsTsAggregation new.
 		aggregationBlock cull: aggOptions aggregation cull: aggOptions ].
 	args := self
 		tsRangeArgsFor: cmdName key: key
@@ -498,7 +497,6 @@ RsRedisEndpoint >> tsExecuteMRange: cmdName rangeBy: rangeBlock filterBy: filter
 		optionsBlock value: options ].
 	aggregationBlock ifNotNil: [
 		aggOptions := RsTsAggregationOptions new.
-		aggOptions aggregation: RsTsAggregation new.
 		aggregationBlock cull: aggOptions aggregation cull: aggOptions ].
 	groupingBlock ifNotNil: [
 		groupBy := RsTsGroupBy new.

--- a/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
+++ b/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
@@ -19,7 +19,7 @@ RsTsAggregationOptions >> initialize [
 
 { #category : 'accessing' }
 RsTsAggregationOptions >> aggregation [
-	^ aggregation
+	^ aggregation ifNil: [ aggregation := RsTsAggregation new ]
 ]
 
 { #category : 'accessing' }

--- a/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
+++ b/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'align',
 		'bucketTimestamp',
-		'empty'
+		'empty',
+		'aggregation'
 	],
 	#category : 'RediStick-TimeSeries',
 	#package : 'RediStick-TimeSeries'
@@ -17,13 +18,18 @@ RsTsAggregationOptions >> initialize [
 ]
 
 { #category : 'accessing' }
-RsTsAggregationOptions >> align [
-	^ align
+RsTsAggregationOptions >> aggregation [
+	^ aggregation
 ]
 
-{ #category : 'converting' }
-RsTsAggregationOptions >> alignArray [
-	^ self align ifNil: [ #() ] ifNotNil: [ { 'ALIGN'. self align } ]
+{ #category : 'accessing' }
+RsTsAggregationOptions >> aggregation: anAggregation [
+	aggregation := anAggregation
+]
+
+{ #category : 'accessing' }
+RsTsAggregationOptions >> align [
+	^ align
 ]
 
 { #category : 'accessing' }
@@ -52,9 +58,11 @@ RsTsAggregationOptions >> isEmpty [
 ]
 
 { #category : 'converting' }
-RsTsAggregationOptions >> tailArray [
+RsTsAggregationOptions >> asArray [
 	| opts |
 	opts := OrderedCollection new.
+	self align ifNotNil: [ :a | opts addAll: { 'ALIGN'. a } ].
+	self aggregation ifNotNil: [ opts addAll: self aggregation asArray ].
 	self bucketTimestamp ifNotNil: [ :bt | opts addAll: { 'BUCKETTIMESTAMP'. bt } ].
 	self isEmpty ifTrue: [ opts add: 'EMPTY' ].
 	^ opts asArray

--- a/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
+++ b/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
@@ -62,7 +62,7 @@ RsTsAggregationOptions >> asArray [
 	| opts |
 	opts := OrderedCollection new.
 	self align ifNotNil: [ :a | opts addAll: { 'ALIGN'. a } ].
-	self aggregation ifNotNil: [ opts addAll: self aggregation asArray ].
+	opts addAll: self aggregation asArray.
 	self bucketTimestamp ifNotNil: [ :bt | opts addAll: { 'BUCKETTIMESTAMP'. bt } ].
 	self isEmpty ifTrue: [ opts add: 'EMPTY' ].
 	^ opts asArray

--- a/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
+++ b/src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
@@ -57,6 +57,31 @@ RsTsAggregationOptions >> isEmpty [
 	^ empty
 ]
 
+{ #category : 'shortcuts-align' }
+RsTsAggregationOptions >> alignEnd [
+	self align: RsTsRange end
+]
+
+{ #category : 'shortcuts-align' }
+RsTsAggregationOptions >> alignStart [
+	self align: RsTsRange start
+]
+
+{ #category : 'shortcuts-bucketTimestamp' }
+RsTsAggregationOptions >> bucketTimestampEnd [
+	self bucketTimestamp: RsTsRange end
+]
+
+{ #category : 'shortcuts-bucketTimestamp' }
+RsTsAggregationOptions >> bucketTimestampMid [
+	self bucketTimestamp: RsTsRange mid
+]
+
+{ #category : 'shortcuts-bucketTimestamp' }
+RsTsAggregationOptions >> bucketTimestampStart [
+	self bucketTimestamp: RsTsRange start
+]
+
 { #category : 'converting' }
 RsTsAggregationOptions >> asArray [
 	| opts |

--- a/src/RediStick-TimeSeries/RsTsGroupBy.class.st
+++ b/src/RediStick-TimeSeries/RsTsGroupBy.class.st
@@ -29,6 +29,80 @@ RsTsGroupBy >> reduce: aReducer [
 	reducer := aReducer
 ]
 
+{ #category : 'accessing' }
+RsTsGroupBy >> reduceBy: aBlock [
+	| r |
+	r := RsTsReducer new.
+	aBlock value: r.
+	r reducerName ifNil: [ Error signal: 'reducer block must set a reducer' ].
+	reducer := r reducerName
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByAvg [
+	self reduceBy: [ :r | r avg ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByCount [
+	self reduceBy: [ :r | r count ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByFirst [
+	self reduceBy: [ :r | r first ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByLast [
+	self reduceBy: [ :r | r last ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByMax [
+	self reduceBy: [ :r | r max ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByMin [
+	self reduceBy: [ :r | r min ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByRange [
+	self reduceBy: [ :r | r range ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByStdP [
+	self reduceBy: [ :r | r stdP ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByStdS [
+	self reduceBy: [ :r | r stdS ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceBySum [
+	self reduceBy: [ :r | r sum ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByTwa [
+	self reduceBy: [ :r | r twa ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByVarP [
+	self reduceBy: [ :r | r varP ]
+]
+
+{ #category : 'shortcuts-reducer' }
+RsTsGroupBy >> reduceByVarS [
+	self reduceBy: [ :r | r varS ]
+]
+
 { #category : 'converting' }
 RsTsGroupBy >> asArray [
 	self label ifNil: [ Error signal: 'label must be set' ].

--- a/src/RediStick-TimeSeries/RsTsRange.class.st
+++ b/src/RediStick-TimeSeries/RsTsRange.class.st
@@ -14,10 +14,6 @@ RsTsRange class >> all [
 	^ self from: self start to: self end
 ]
 
-{ #category : 'instance creation' }
-RsTsRange class >> end [
-	^ '+'
-]
 
 { #category : 'instance creation' }
 RsTsRange class >> from: aFrom [
@@ -31,20 +27,30 @@ RsTsRange class >> from: aFrom to: aTo [
 		to: (self normalizeTimestamp: aTo)
 ]
 
+{ #category : 'instance creation' }
+RsTsRange class >> to: aTo [
+	^ self from: self start to: aTo
+]
+
 { #category : 'private' }
 RsTsRange class >> normalizeTimestamp: aValue [
 	aValue isString ifTrue: [ ^ aValue ].
 	^ aValue asRediStickUnixTimestampMillis
 ]
 
-{ #category : 'instance creation' }
+{ #category : 'constants' }
 RsTsRange class >> start [
 	^ '-'
 ]
 
-{ #category : 'instance creation' }
-RsTsRange class >> to: aTo [
-	^ self from: self start to: aTo
+{ #category : 'constants' }
+RsTsRange class >> end [
+	^ '~'
+]
+
+{ #category : 'constants' }
+RsTsRange class >> mid [
+	^ '+'
 ]
 
 { #category : 'converting' }

--- a/src/RediStick-TimeSeries/RsTsRange.class.st
+++ b/src/RediStick-TimeSeries/RsTsRange.class.st
@@ -45,12 +45,12 @@ RsTsRange class >> start [
 
 { #category : 'constants' }
 RsTsRange class >> end [
-	^ '~'
+	^ '+'
 ]
 
 { #category : 'constants' }
 RsTsRange class >> mid [
-	^ '+'
+	^ '~'
 ]
 
 { #category : 'converting' }

--- a/src/RediStick-TimeSeries/RsTsReducer.class.st
+++ b/src/RediStick-TimeSeries/RsTsReducer.class.st
@@ -1,0 +1,96 @@
+Class {
+	#name : 'RsTsReducer',
+	#superclass : 'Object',
+	#instVars : [
+		'reducerName'
+	],
+	#category : 'RediStick-TimeSeries',
+	#package : 'RediStick-TimeSeries'
+}
+
+{ #category : 'accessing' }
+RsTsReducer >> reducerName [
+	^ reducerName
+]
+
+{ #category : 'accessing' }
+RsTsReducer >> reducerName: aString [
+	reducerName := aString
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> avg [
+	self reducerName: 'avg'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> count [
+	self reducerName: 'count'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> countAll [
+	"Requires Redis TimeSeries 8.6+"
+	self reducerName: 'countAll'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> countNaN [
+	"Requires Redis TimeSeries 8.6+"
+	self reducerName: 'countNaN'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> first [
+	self reducerName: 'first'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> last [
+	self reducerName: 'last'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> max [
+	self reducerName: 'max'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> min [
+	self reducerName: 'min'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> range [
+	self reducerName: 'range'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> stdP [
+	self reducerName: 'std.p'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> stdS [
+	self reducerName: 'std.s'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> sum [
+	self reducerName: 'sum'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> twa [
+	self reducerName: 'twa'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> varP [
+	self reducerName: 'var.p'
+]
+
+{ #category : 'reducers' }
+RsTsReducer >> varS [
+	self reducerName: 'var.s'
+]


### PR DESCRIPTION
## Summary
- Refactored RsTsAggregationOptions to always include aggregation and lazy initialize aggregation
- Added shortcut methods to RsTsAggregationOptions and fixed RsTsRange constants (added mid constant)
- Added TimeSeries reducer support to RsTsGroupBy with new RsTsReducer class
- Added RsTsGroupBy class for TimeSeries grouping operations
- Updated RsTsAggregationOptionsTest and added RsTsGroupByTest

### Changes
- Refactor RsTsAggregationOptions to always include aggregation and lazy initialize aggregation
- Refactor RsTsRange constants and add mid constant
- Add shortcut methods to RsTsAggregationOptions and fix RsTsRange constants
- Add TimeSeries reducer support to RsTsGroupBy
- Add RsTsGroupBy class for TimeSeries grouping operations
- Add RsTsReducer class for TimeSeries reducer operations
- Add and update tests for RsTsAggregationOptions and RsTsGroupBy
- Update RsRedisEndpoint extension for TimeSeries

### Commits Included
bfb2c93 Add shortcut methods to RsTsAggregationOptions and fix RsTsRange constants
72f467f Refactor RsTsRange constants and add mid constant
5a79245 Refactor RsTsAggregationOptions to always include aggregation
9bc9960 Refactor RsTsAggregationOptions to lazy initialize aggregation
d48f924 Refactor TimeSeries aggregation options
01d6450 Add TimeSeries reducer support to RsTsGroupBy

### Files Changed
src/RediStick-TimeSeries-Tests/RsTsAggregationOptionsTest.class.st
src/RediStick-TimeSeries-Tests/RsTsGroupByTest.class.st
src/RediStick-TimeSeries/RsRedisEndpoint.extension.st
src/RediStick-TimeSeries/RsTsAggregationOptions.class.st
src/RediStick-TimeSeries/RsTsGroupBy.class.st
src/RediStick-TimeSeries/RsTsRange.class.st
src/RediStick-TimeSeries/RsTsReducer.class.st