### PR TITLE
test: relax stream XINFO radixTreeNodes assertions

### DIFF
--- a/src/RediStick-Stream-Tests/RsRedisEndpointTest.extension.st
+++ b/src/RediStick-Stream-Tests/RsRedisEndpointTest.extension.st
@@ -498,7 +498,7 @@ RsRedisEndpointTest >> testXInfoStream [
 	streamInfo := stick endpoint xInfoStream: streamKey.
 	self assert: streamInfo size equals: 3.
 	self assert: streamInfo radixTreeKeys equals: 1.
-	self assert: streamInfo radixTreeNodes equals: 2.
+	self assert: streamInfo radixTreeNodes >= streamInfo radixTreeKeys.
 	self assert: streamInfo groups equals: 1.
 	self assert: streamInfo lastGeneratedId equals: ents2 last id.
 	self assert: streamInfo maxDeletedEntryId equals: '0-0'.
@@ -538,7 +538,7 @@ RsRedisEndpointTest >> testXInfoStreamFull [
 	streamInfo := stick endpoint xInfoStream: streamKey full: true count: 2.
 	self assert: streamInfo size equals: 3.
 	self assert: streamInfo radixTreeKeys equals: 1.
-	self assert: streamInfo radixTreeNodes equals: 2.
+	self assert: streamInfo radixTreeNodes >= streamInfo radixTreeKeys.
 	self assert: streamInfo groups size equals: 1.
 	group := streamInfo groups first.
 	self assert: group name equals: 'group-a'.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- relax `RsRedisEndpointTest>>testXInfoStream` assertion for `radixTreeNodes`
- relax `RsRedisEndpointTest>>testXInfoStreamFull` assertion for `radixTreeNodes`
- replace fixed-value expectation (`= 2`) with a property-based check (`radixTreeNodes >= radixTreeKeys`) to tolerate Redis internal implementation changes across 8.x versions

## Why
`redis:8` is a moving tag. Recent CI failures occurred after the image moved from Redis 8.8.1 to 8.10.0, where `XINFO STREAM` now reports `radix-tree-nodes = 1` for this scenario.

## Verification
- `git diff --check` (pass)
- `smalltalkci -s Pharo64-13` could not be executed in this environment (`smalltalkci: command not found`), so CI run is the effective validation gate for runtime behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-390e3ad0-c028-4dc8-ab33-27c10da91ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-390e3ad0-c028-4dc8-ab33-27c10da91ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

