### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "RediStick",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install phase for RediStick.
+# Installs the two things the project needs to build and test:
+#   1. Redis 8 (Community Edition) with the bundled JSON / Search / TimeSeries /
+#      Bloom / VectorSet modules, matching the `redis:8` service used in CI.
+#   2. The smalltalkCI test runner, which downloads the pinned Pharo VM + image
+#      on first use.
+#
+# The script is idempotent: it can run repeatedly against a clean or a partially
+# prepared machine.
+set -euo pipefail
+
+REDIS_KEYRING=/usr/share/keyrings/redis-archive-keyring.gpg
+REDIS_LIST=/etc/apt/sources.list.d/redis.list
+SMALLTALKCI_HOME="${HOME}/smalltalkCI"
+
+install_redis() {
+  if command -v redis-server >/dev/null 2>&1; then
+    echo "redis-server already installed: $(redis-server --version)"
+    return 0
+  fi
+
+  echo "Installing Redis 8 from packages.redis.io ..."
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq lsb-release curl gpg ca-certificates
+
+  curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o "${REDIS_KEYRING}"
+  sudo chmod 644 "${REDIS_KEYRING}"
+  echo "deb [signed-by=${REDIS_KEYRING}] https://packages.redis.io/deb $(lsb_release -cs) main" \
+    | sudo tee "${REDIS_LIST}" >/dev/null
+
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq redis
+  echo "Installed: $(redis-server --version)"
+}
+
+install_smalltalkci() {
+  if [ ! -d "${SMALLTALKCI_HOME}" ]; then
+    echo "Cloning smalltalkCI ..."
+    git clone --depth 1 https://github.com/hpi-swa/smalltalkCI.git "${SMALLTALKCI_HOME}"
+  else
+    echo "smalltalkCI already present at ${SMALLTALKCI_HOME}"
+  fi
+  sudo ln -sf "${SMALLTALKCI_HOME}/bin/smalltalkci" /usr/local/bin/smalltalkci
+  echo "smalltalkci available at $(command -v smalltalkci)"
+}
+
+install_redis
+install_smalltalkci
+
+echo "RediStick install phase complete."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent start phase for RediStick.
+# Brings up a local Redis 8 server with the modules RediStick exercises
+# (Search, JSON, TimeSeries, Bloom; VectorSet is built into Redis 8 core).
+# Idempotent: a no-op if Redis is already responding.
+set -euo pipefail
+
+MODULES_DIR=/usr/lib/redis/modules
+
+if redis-cli ping >/dev/null 2>&1; then
+  echo "Redis already running."
+  exit 0
+fi
+
+module_flags=()
+for mod in redisearch rejson redistimeseries redisbloom; do
+  if [ -f "${MODULES_DIR}/${mod}.so" ]; then
+    module_flags+=(--loadmodule "${MODULES_DIR}/${mod}.so")
+  fi
+done
+
+redis-server --daemonize yes --save "" --appendonly no "${module_flags[@]}"
+
+for _ in $(seq 1 30); do
+  if redis-cli ping >/dev/null 2>&1; then
+    echo "Redis is ready."
+    redis-cli module list | tr '\n' ' '
+    echo
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Redis did not become ready in time." >&2
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # Claude
 CLAUDE.local.md
+
+# smalltalkCI test result output (e.g. Pharo64-13.xml)
+Pharo64-*.xml
+Pharo32-*.xml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for RediStick so agents can build, test, and run the library out of the box. Adds a repository-managed `.cursor/environment.json` plus idempotent `install` and `start` scripts.

The environment mirrors the CI setup in `.github/workflows/main.yml` (which tests against the `redis:8` service with `smalltalkci`).

## What was added

- `.cursor/environment.json` — points `install` at `.cursor/install.sh` and `start` at `.cursor/start.sh`.
- `.cursor/install.sh` — installs Redis 8 Community Edition (bundling the Search / JSON / TimeSeries / Bloom / VectorSet modules the tests exercise) from `packages.redis.io`, and the `smalltalkCI` test runner (which pulls the pinned Pharo VM + image on first use). Idempotent.
- `.cursor/start.sh` — launches Redis on each boot with the required modules and waits for readiness. Idempotent (no-op if Redis is already up).
- `.gitignore` — ignore smalltalkCI's `Pharo64-*.xml` / `Pharo32-*.xml` test-result output.

## Validation

Local VM:

- Full suite via `smalltalkci -s Pharo64-13`: **289 tests, 0 failures, 0 errors** against live Redis with all modules.
- `install.sh` run twice — idempotent.
- `start.sh` cold-start brings Redis up with `search`, `ReJSON`, `timeseries`, `vectorset`, and `bf` (bloom).
- Hello-world exercise of the real RediStick API (strings, counters, RedisJSON):

```
--- RediStick end-to-end demo ---
PING         -> 'PONG'
GET greeting  -> 'hello from RediStick'
INCR counter  -> '16'
JSON .name    -> RsJsonResult(#('Alice'))
JSON .age+1   -> RsJsonResult(#(31))
DBSIZE        -> 3
--- demo complete ---
```

From-scratch environment build + fresh Cloud Agent verification:

- Draft build ran `.cursor/install.sh` from a clean image — **SUCCEEDED** (installed Redis 8.10.1, cloned smalltalkCI).
- A fresh Cloud Agent booted from that build: `.cursor/start.sh` brought Redis up with all 5 modules, `smalltalkci` available, full suite **`Executed 289 Tests with 0 Failures and 0 Errors in 20.33s.`**

## Activation

Because `.cursor/environment.json` is committed, it is the highest-precedence environment source. Merging this PR makes the setup available to future Cloud Agents on the branch — no dashboard configuration needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5830d00d-0e4e-442e-8106-aa2132aedb77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5830d00d-0e4e-442e-8106-aa2132aedb77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

