### PR TITLE
Fix ZnInvalidUTF8 crash in VEMB RAW command

### DIFF
--- a/src/RediStick-Core/RsRedisEndpoint.class.st
+++ b/src/RediStick-Core/RsRedisEndpoint.class.st
@@ -688,6 +688,21 @@ RsRedisEndpoint >> parseBulkReply [
 ]
 
 { #category : 'private replies' }
+RsRedisEndpoint >> parseBulkReplyRaw [
+	"like #parseBulkReply, but skips UTF-8 decoding and answers the raw
+	ByteArray bytes as read off the socket. Used for replies that may
+	contain binary (non-UTF-8) data, e.g. VEMB ... RAW."
+	| length reply |
+	length := self parseInteger.
+	length = -1
+		ifTrue: [ reply := nil ]
+		ifFalse: [
+			reply := self socketStream next: length.
+			self socketStream next: 2 "skip separators"].
+	^ reply
+]
+
+{ #category : 'private replies' }
 RsRedisEndpoint >> parseError [
 	| error |
 	error := RsGenericError errorMessage: self parseSingleLine.
@@ -713,6 +728,20 @@ RsRedisEndpoint >> parseMultiBulkReply [
 ]
 
 { #category : 'private replies' }
+RsRedisEndpoint >> parseMultiBulkReplyRaw [
+	"like #parseMultiBulkReply, but recurses through #parseReplyRaw so
+	nested bulk strings are left as raw ByteArray bytes."
+	| count reply |
+	count := self parseInteger.
+	count = -1
+		ifTrue: [^ nil].
+	reply := OrderedCollection new.
+	count
+		timesRepeat: [reply add: self parseReplyRaw].
+	^ reply
+]
+
+{ #category : 'private replies' }
 RsRedisEndpoint >> parseReply [
 	| strm replyToken |
 	strm := self socketStream ifNil: [ ^nil ].
@@ -728,6 +757,28 @@ RsRedisEndpoint >> parseReply [
 	replyToken = 45 "$- asInteger"
 		ifTrue: [^ self parseError].
 		
+	(RsError invalidReplyToken) signal
+]
+
+{ #category : 'private replies' }
+RsRedisEndpoint >> parseReplyRaw [
+	"like #parseReply, but bulk strings (and nested bulk strings within
+	multi-bulk replies) are answered as raw ByteArray bytes rather than
+	being UTF-8 decoded."
+	| strm replyToken |
+	strm := self socketStream ifNil: [ ^nil ].
+	replyToken := [strm next] on: Error do: [:ex | (RsError canNotGetReply) signal].
+	replyToken = 43 "$+ asInteger"
+		ifTrue: [^ self parseSingleLine].
+	replyToken = 58 "$: asInteger"
+		ifTrue: [^ self parseInteger].
+	replyToken = 36 "$$ asInteger"
+		ifTrue: [^ self parseBulkReplyRaw].
+	replyToken = 42 "$* asInteger"
+		ifTrue: [^ self parseMultiBulkReplyRaw].
+	replyToken = 45 "$- asInteger"
+		ifTrue: [^ self parseError].
+
 	(RsError invalidReplyToken) signal
 ]
 
@@ -854,6 +905,22 @@ RsRedisEndpoint >> rPush: aKey value: aValue [
 { #category : 'commands-generic' }
 RsRedisEndpoint >> randomKey [
 	^ self inlineCommand: 'RANDOMKEY'
+]
+
+{ #category : 'private commands' }
+RsRedisEndpoint >> rawUnifiedCommand: args [
+	"like #unifiedCommand:, but parses the reply via #parseReplyRaw so any
+	bulk-string elements are answered as raw ByteArray bytes instead of
+	being UTF-8 decoded. Use for commands whose reply may carry binary
+	data, e.g. VEMB ... RAW."
+	| received |
+	received := nil.
+	self sendMutex
+		critical: [ self
+				errorHandlingDo: [ self writeUnifiedCommand: args.
+					pubsub ifFalse: [ received := self parseReplyRaw ] ].
+			received ifNotNil: [ self onDataReceived: received ] ].
+	^ received
 ]
 
 { #category : 'private replies' }

--- a/src/RediStick-Core/RsRedisEndpoint.class.st
+++ b/src/RediStick-Core/RsRedisEndpoint.class.st
@@ -677,21 +677,14 @@ RsRedisEndpoint >> onRedisGenericErrorSignaled: aRsGenericError [
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseBulkReply [
-	| length reply |
-	length := self parseInteger.
-	length = -1
-		ifTrue: [ reply := nil ]
-		ifFalse: [ 
-			reply := self socketStream next: length.
-			self socketStream next: 2 "skip separators"].
-	^ self stringFromUtf8Bytes: reply
+	^ self stringFromUtf8Bytes: self parseBulkReplyRaw
 ]
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseBulkReplyRaw [
-	"like #parseBulkReply, but skips UTF-8 decoding and answers the raw
-	ByteArray bytes as read off the socket. Used for replies that may
-	contain binary (non-UTF-8) data, e.g. VEMB ... RAW."
+	"Answer the raw ByteArray bytes of a bulk-string reply as read off the
+	socket, without UTF-8 decoding. Used for replies that may contain
+	binary (non-UTF-8) data, e.g. VEMB ... RAW."
 	| length reply |
 	length := self parseInteger.
 	length = -1
@@ -717,54 +710,38 @@ RsRedisEndpoint >> parseInteger [
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseMultiBulkReply [
-	| count reply |
-	count := self parseInteger.
-	count = -1
-		ifTrue: [^ nil].
-	reply := OrderedCollection new.
-	count
-		timesRepeat: [reply add: self parseReply].
-	^ reply
+	^ self parseMultiBulkReplyWithRaw: false
 ]
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseMultiBulkReplyRaw [
-	"like #parseMultiBulkReply, but recurses through #parseReplyRaw so
-	nested bulk strings are left as raw ByteArray bytes."
+	^ self parseMultiBulkReplyWithRaw: true
+]
+
+{ #category : 'private replies' }
+RsRedisEndpoint >> parseMultiBulkReplyWithRaw: aBoolean [
 	| count reply |
 	count := self parseInteger.
 	count = -1
 		ifTrue: [^ nil].
 	reply := OrderedCollection new.
 	count
-		timesRepeat: [reply add: self parseReplyRaw].
+		timesRepeat: [reply add: (self parseReplyWithRaw: aBoolean)].
 	^ reply
 ]
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseReply [
-	| strm replyToken |
-	strm := self socketStream ifNil: [ ^nil ].
-	replyToken := [strm next] on: Error do: [:ex | (RsError canNotGetReply) signal].
-	replyToken = 43 "$+ asInteger"
-		ifTrue: [^ self parseSingleLine].
-	replyToken = 58 "$: asInteger"
-		ifTrue: [^ self parseInteger].
-	replyToken = 36 "$$ asInteger"
-		ifTrue: [^ self parseBulkReply].
-	replyToken = 42 "$* asInteger"
-		ifTrue: [^ self parseMultiBulkReply].
-	replyToken = 45 "$- asInteger"
-		ifTrue: [^ self parseError].
-		
-	(RsError invalidReplyToken) signal
+	^ self parseReplyWithRaw: false
 ]
 
 { #category : 'private replies' }
 RsRedisEndpoint >> parseReplyRaw [
-	"like #parseReply, but bulk strings (and nested bulk strings within
-	multi-bulk replies) are answered as raw ByteArray bytes rather than
-	being UTF-8 decoded."
+	^ self parseReplyWithRaw: true
+]
+
+{ #category : 'private replies' }
+RsRedisEndpoint >> parseReplyWithRaw: aBoolean [
 	| strm replyToken |
 	strm := self socketStream ifNil: [ ^nil ].
 	replyToken := [strm next] on: Error do: [:ex | (RsError canNotGetReply) signal].
@@ -773,9 +750,11 @@ RsRedisEndpoint >> parseReplyRaw [
 	replyToken = 58 "$: asInteger"
 		ifTrue: [^ self parseInteger].
 	replyToken = 36 "$$ asInteger"
-		ifTrue: [^ self parseBulkReplyRaw].
+		ifTrue: [^ aBoolean
+			ifTrue: [ self parseBulkReplyRaw ]
+			ifFalse: [ self parseBulkReply ]].
 	replyToken = 42 "$* asInteger"
-		ifTrue: [^ self parseMultiBulkReplyRaw].
+		ifTrue: [^ self parseMultiBulkReplyWithRaw: aBoolean].
 	replyToken = 45 "$- asInteger"
 		ifTrue: [^ self parseError].
 
@@ -913,14 +892,7 @@ RsRedisEndpoint >> rawUnifiedCommand: args [
 	bulk-string elements are answered as raw ByteArray bytes instead of
 	being UTF-8 decoded. Use for commands whose reply may carry binary
 	data, e.g. VEMB ... RAW."
-	| received |
-	received := nil.
-	self sendMutex
-		critical: [ self
-				errorHandlingDo: [ self writeUnifiedCommand: args.
-					pubsub ifFalse: [ received := self parseReplyRaw ] ].
-			received ifNotNil: [ self onDataReceived: received ] ].
-	^ received
+	^ self sendUnifiedCommand: args parseWithRaw: true
 ]
 
 { #category : 'private replies' }
@@ -1223,15 +1195,22 @@ RsRedisEndpoint >> type: aKey [
 ]
 
 { #category : 'private commands' }
-RsRedisEndpoint >> unifiedCommand: args [
+RsRedisEndpoint >> sendUnifiedCommand: args parseWithRaw: aBoolean [
 	| received |
 	received := nil.
 	self sendMutex
 		critical: [ self
 				errorHandlingDo: [ self writeUnifiedCommand: args.
-					pubsub ifFalse: [ received := self parseReply ] ].
+					pubsub ifFalse: [ received := aBoolean
+						ifTrue: [ self parseReplyRaw ]
+						ifFalse: [ self parseReply ] ] ].
 			received ifNotNil: [ self onDataReceived: received ] ].
 	^ received
+]
+
+{ #category : 'private commands' }
+RsRedisEndpoint >> unifiedCommand: args [
+	^ self sendUnifiedCommand: args parseWithRaw: false
 ]
 
 { #category : 'private' }

--- a/src/RediStick-VectorSet-Tests/RsVectorSetTest.class.st
+++ b/src/RediStick-VectorSet-Tests/RsVectorSetTest.class.st
@@ -157,13 +157,54 @@ RsVectorSetTest >> testVEmbRoundTrip [
 ]
 
 { #category : 'tests' }
-RsVectorSetTest >> testVEmbRaw [
+RsVectorSetTest >> testVEmbRawWithDefaultQuantization [
 	| raw |
-	stick endpoint vAdd: 'vs:embraw' element: 'elem1' vector: self class sampleVectorA using: nil.
-	raw := stick endpoint vEmb: 'vs:embraw' element: 'elem1' raw: true.
-	self assert: raw first equals: 'int8'.
-	self assert: (stick endpoint vEmb: 'vs:embraw' element: 'elem1' raw: false)
-		equals: (stick endpoint vEmb: 'vs:embraw' element: 'elem1')
+	stick endpoint vAdd: 'vs:embraw:q8' element: 'elem1' vector: self class sampleVectorA using: nil.
+	raw := stick endpoint vEmb: 'vs:embraw:q8' element: 'elem1' raw: true.
+	self assert: raw quantType equals: 'int8'.
+	self assert: raw bytes size equals: self class sampleVectorA size.
+	self assert: raw l2Norm notNil.
+	self assert: raw quantRange notNil
+]
+
+{ #category : 'tests' }
+RsVectorSetTest >> testVEmbRawWithNoQuantization [
+	| raw decoded |
+	stick endpoint
+		vAdd: 'vs:embraw:fp32'
+		element: 'elem1'
+		vector: self class sampleVectorA
+		using: [ :options | options noQuantization ].
+	raw := stick endpoint vEmb: 'vs:embraw:fp32' element: 'elem1' raw: true.
+	self assert: raw quantType equals: 'f32'.
+	self assert: raw quantRange equals: nil.
+	decoded := self class floatsFromFp32Bytes: raw bytes.
+	self assert: decoded size equals: self class sampleVectorA size.
+	"Redis stores the vector unit-normalized; multiply back by l2Norm to
+	recover the original magnitudes."
+	decoded with: self class sampleVectorA do: [ :actual :expected |
+		self assert: ((actual * raw l2Norm) - expected) abs < 0.01 ]
+]
+
+{ #category : 'tests' }
+RsVectorSetTest >> testVEmbRawWithBinQuantization [
+	| raw |
+	stick endpoint
+		vAdd: 'vs:embraw:bin'
+		element: 'elem1'
+		vector: self class sampleVectorA
+		using: [ :options | options quantizationBin ].
+	raw := stick endpoint vEmb: 'vs:embraw:bin' element: 'elem1' raw: true.
+	self assert: raw quantType equals: 'bin'.
+	self assert: raw bytes notEmpty.
+	self assert: raw quantRange equals: nil
+]
+
+{ #category : 'tests' }
+RsVectorSetTest >> testVEmbRawFalseMatchesVEmb [
+	stick endpoint vAdd: 'vs:embraw:false' element: 'elem1' vector: self class sampleVectorA using: nil.
+	self assert: (stick endpoint vEmb: 'vs:embraw:false' element: 'elem1' raw: false)
+		equals: (stick endpoint vEmb: 'vs:embraw:false' element: 'elem1')
 ]
 
 { #category : 'tests' }

--- a/src/RediStick-VectorSet-Tests/RsVectorSetTestCase.class.st
+++ b/src/RediStick-VectorSet-Tests/RsVectorSetTestCase.class.st
@@ -41,3 +41,19 @@ RsVectorSetTestCase class >> fp32BytesFor: aNumberCollection [
 		1 to: 4 do: [ :i | bytes at: offset + i put: ((word >> ((i - 1) * 8)) bitAnd: 255) ] ].
 	^ bytes
 ]
+
+{ #category : 'fixtures' }
+RsVectorSetTestCase class >> floatsFromFp32Bytes: aByteArray [
+	"Inverse of #fp32BytesFor: - decodes 32-bit little-endian float bytes
+	(as answered by VEMB ... RAW for fp32/NOQUANT vectors) back into Floats."
+	| count floats |
+	count := aByteArray size // 4.
+	floats := Array new: count.
+	1 to: count do: [ :index |
+		| word offset |
+		offset := (index - 1) * 4.
+		word := 0.
+		4 to: 1 by: -1 do: [ :i | word := (word << 8) bitOr: (aByteArray at: offset + i) ].
+		floats at: index put: (Float fromIEEE32Bit: word) ].
+	^ floats
+]

--- a/src/RediStick-VectorSet/RsRedisEndpoint.extension.st
+++ b/src/RediStick-VectorSet/RsRedisEndpoint.extension.st
@@ -67,7 +67,36 @@ RsRedisEndpoint >> vEmb: key element: element [
 { #category : '*RediStick-VectorSet' }
 RsRedisEndpoint >> vEmb: key element: element raw: aBoolean [
 	aBoolean ifFalse: [ ^ self vEmb: key element: element ].
-	^ self unifiedCommand: { 'VEMB'. key. element. 'RAW' }
+	^ self vEmbRaw: key element: element
+]
+
+{ #category : '*RediStick-VectorSet-private' }
+RsRedisEndpoint >> vEmbRaw: key element: element [
+	"private - parses the VEMB ... RAW reply into a RsVectorSetRawEmbedding.
+	Uses #rawUnifiedCommand: instead of #unifiedCommand: because the
+	vector-bytes element (2nd) is a binary bulk string that must not be
+	forced through UTF-8 decoding; the other elements arrive as RESP
+	simple strings and are already decoded Strings."
+	| result |
+	result := self rawUnifiedCommand: { 'VEMB'. key. element. 'RAW' }.
+	result ifNil: [ ^ nil ].
+	^ RsVectorSetRawEmbedding
+		quantType: (self vEmbRawElementAsString: (result at: 1))
+		bytes: (result at: 2)
+		l2Norm: (self vEmbRawElementAsString: (result at: 3)) asNumber
+		quantRange: (result size >= 4
+			ifTrue: [ (self vEmbRawElementAsString: (result at: 4)) asNumber ]
+			ifFalse: [ nil ])
+]
+
+{ #category : '*RediStick-VectorSet-private' }
+RsRedisEndpoint >> vEmbRawElementAsString: aStringOrByteArray [
+	"private - VEMB ... RAW's non-blob elements arrive as RESP simple
+	strings (already decoded Strings via #parseSingleLine), but tolerate a
+	bulk-string encoding too by decoding ByteArray instances."
+	^ aStringOrByteArray isString
+		ifTrue: [ aStringOrByteArray ]
+		ifFalse: [ self stringFromUtf8Bytes: aStringOrByteArray ]
 ]
 
 { #category : '*RediStick-VectorSet' }

--- a/src/RediStick-VectorSet/RsVectorSetRawEmbedding.class.st
+++ b/src/RediStick-VectorSet/RsVectorSetRawEmbedding.class.st
@@ -1,0 +1,89 @@
+"
+I represent the parsed reply of a Redis VEMB ... RAW command.
+
+Responsibility:
+- I wrap the raw quantized embedding bytes together with the metadata
+  needed to interpret them: the quantization type, the L2 norm applied
+  before quantization, and (for Q8 only) the quantization range.
+
+Collaborators:
+- RsRedisEndpoint: builds instances of me from VEMB ... RAW replies in
+  #vEmb:element:raw:.
+
+Public API and Key Messages:
+- #quantType - 'fp32', 'bin', or 'q8'.
+- #bytes - the raw quantized vector as a ByteArray (4-byte little-endian
+  floats for fp32, a bitmap for bin, a byte array for q8).
+- #l2Norm - the L2 norm (Float) of the vector before normalization.
+- #quantRange - the quantization range (Float), only present for q8;
+  multiply by integer components to recover normalized values.
+
+Internal Representation:
+- quantType - String.
+- bytes - ByteArray.
+- l2Norm - Float.
+- quantRange - Float or nil.
+"
+Class {
+	#name : 'RsVectorSetRawEmbedding',
+	#superclass : 'Object',
+	#instVars : [
+		'quantType',
+		'bytes',
+		'l2Norm',
+		'quantRange'
+	],
+	#category : 'RediStick-VectorSet',
+	#package : 'RediStick-VectorSet'
+}
+
+{ #category : 'instance creation' }
+RsVectorSetRawEmbedding class >> quantType: aQuantTypeString bytes: aByteArray l2Norm: aL2Norm quantRange: aQuantRangeOrNil [
+	^ self new
+		setQuantType: aQuantTypeString
+		bytes: aByteArray
+		l2Norm: aL2Norm
+		quantRange: aQuantRangeOrNil
+]
+
+{ #category : 'accessing' }
+RsVectorSetRawEmbedding >> bytes [
+	^ bytes
+]
+
+{ #category : 'accessing' }
+RsVectorSetRawEmbedding >> l2Norm [
+	^ l2Norm
+]
+
+{ #category : 'printing' }
+RsVectorSetRawEmbedding >> printOn: aStream [
+	aStream
+		nextPutAll: 'RsVectorSetRawEmbedding(quantType: ';
+		print: self quantType;
+		nextPutAll: ' bytes: ';
+		print: self bytes size;
+		nextPutAll: ' bytes l2Norm: ';
+		print: self l2Norm;
+		nextPutAll: ' quantRange: ';
+		print: self quantRange;
+		nextPut: $)
+]
+
+{ #category : 'accessing' }
+RsVectorSetRawEmbedding >> quantRange [
+	^ quantRange
+]
+
+{ #category : 'accessing' }
+RsVectorSetRawEmbedding >> quantType [
+	^ quantType
+]
+
+{ #category : 'private' }
+RsVectorSetRawEmbedding >> setQuantType: aQuantTypeString bytes: aByteArray l2Norm: aL2Norm quantRange: aQuantRangeOrNil [
+	quantType := aQuantTypeString.
+	bytes := aByteArray.
+	l2Norm := aL2Norm.
+	quantRange := aQuantRangeOrNil
+]


### PR DESCRIPTION
## Summary
- Fix `RsRedisEndpoint>>vEmb:element:raw:` crashing with `ZnInvalidUTF8` when Redis returns a `VEMB ... RAW` reply, since the binary bulk-string blob was always force-decoded as UTF-8 text by the shared `unifiedCommand:` / `parseBulkReply` path
- Add a parallel, non-decoding reply-parsing path used only for this command: `parseReplyRaw`, `parseBulkReplyRaw`, `parseMultiBulkReplyRaw`, and `rawUnifiedCommand:` in `RsRedisEndpoint`
- Add `RsVectorSetRawEmbedding`, a result class exposing `quantType`, `bytes`, `l2Norm`, and `quantRange` for the raw VEMB reply

## Test plan
- Updated/added tests in `RsVectorSetTest` and `RsVectorSetTestCase` covering `vEmb:element:raw:` against a real Redis Vector Set

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>