### PR TITLE
Fix flaky stream tests caused by timing-sensitive assertions

### DIFF
--- a/src/RediStick-Stream-Objects-Tests/RsStreamConsumerGroupPollerTest.class.st
+++ b/src/RediStick-Stream-Objects-Tests/RsStreamConsumerGroupPollerTest.class.st
@@ -67,7 +67,7 @@ RsStreamConsumerGroupPollerTest >> testPollWithPendings [
 	#(1 2 3 0 4 5 6 7 0) doWithIndex: [ :each :idx | 
 		strm nextPut: (idx  -> each).
 	].
-	(Delay forMilliseconds: 100) wait.
+	[ entries1 size < 7 ] whileTrue: [ (Delay forMilliseconds: 50) wait ].
 	self assert: entries1 size equals: 7.
 	self assert: entries1 first equals: 1.
 	self assert: entries1 last equals: (8/7).
@@ -108,7 +108,7 @@ RsStreamConsumerGroupPollerTest >> testPollWithPendingsAutoClaimed [
 	#(1 2 3 0 4 5 6 7 0) doWithIndex: [ :each :idx | 
 		strm nextPut: (idx  -> each).
 	].
-	(Delay forMilliseconds: 100) wait.
+	[ entries1 size < 7 ] whileTrue: [ (Delay forMilliseconds: 50) wait ].
 	self assert: entries1 size equals: 7.
 	self assert: entries1 first equals: 1.
 	self assert: entries1 last equals: (8/7).
@@ -125,12 +125,13 @@ RsStreamConsumerGroupPollerTest >> testPollWithPendingsAutoClaimed [
 	poller2 := consumer2 poller.
 	poller2 onReceive: [ :each | entries2 add: each].
 	poller2 shouldAutoClaim: true.
-	poller2 claimMinIdleMilliseconds: 10.
+	poller2 claimMinIdleMilliseconds: 50.
 	poller2 start.
 	#(10 11 12) doWithIndex: [ :each :idx | 
 		strm nextPut: (idx  -> each).
 	].
-	[consumerGroup summaryPendingList isEmpty] whileFalse: [(Delay forMilliseconds: 100) wait].
+	[ consumerGroup summaryPendingList isEmpty not
+		or: [ entries2 size < 5 ] ] whileTrue: [ (Delay forMilliseconds: 50) wait ].
 
 	self assert: consumer1 allPendings size equals: 0.
 	self assert: consumer2 allPendings size equals: 0.

--- a/src/RediStick-Stream-Tests/RsRedisEndpointTest.extension.st
+++ b/src/RediStick-Stream-Tests/RsRedisEndpointTest.extension.st
@@ -271,13 +271,13 @@ RsRedisEndpointTest >> testXGroupAutoClaim [
 	stick endpoint xAck: streamKey group: groupKey id: summary minId.
 	(Delay forMilliseconds: 200) wait.
 	
-	claimedA := stick endpoint xAutoClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 10 start: summary minId count: 1 idsOnly: true.
+	claimedA := stick endpoint xAutoClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 50 start: summary minId count: 1 idsOnly: true.
 	self deny: claimedA nextId equals: '0-0'.
 	self assert: claimedA claimedMessages size equals: 1.
 	self assert: claimedA deletedMessages size equals: 0.
 	self assert: (claimedA claimedMessages allSatisfy: [ :each | each isString ]) equals: true.
 	
-	claimedB := stick endpoint xAutoClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 10 start: summary minId.
+	claimedB := stick endpoint xAutoClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 50 start: summary minId.
 	self assert: claimedB nextId equals: '0-0'.
 	self assert: claimedB claimedMessages size equals: 3.
 	self assert: claimedB deletedMessages size equals: 0.
@@ -324,7 +324,7 @@ RsRedisEndpointTest >> testXGroupClaim [
 	(Delay forMilliseconds: 200) wait.
 	
 	pendingsB := stick endpoint xPending: streamKey group: groupKey start: '-' end: '+' count: 2 consumer: consumerKeyB.
-	stick endpoint xClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 10 id: pendingsB first id.
+	stick endpoint xClaim: streamKey group: groupKey consumer: consumerKeyA minIdleTime: 50 id: pendingsB first id.
 	
 	summary := stick endpoint xPending: streamKey group: groupKey.
 	
@@ -414,20 +414,22 @@ RsRedisEndpointTest >> testXInfoConsumers [
 	ents2 := stick endpoint xGroupRead: streamKey id: '>' group: groupKey consumer: consumerKeyB count: 2.
 	
 	stick endpoint xAck: streamKey group: groupKey id: ents1 first id.
-	(Delay forMilliseconds: 100) wait.
+	"Allow enough elapsed time for XINFO CONSUMERS idle/inactive counters to
+	stabilize; CI runners can be slow, so keep a generous margin below the wait."
+	(Delay forMilliseconds: 200) wait.
 	
 	consumerInfoCol := stick endpoint xInfoConsumers: streamKey group: groupKey.
 	self assert: consumerInfoCol size equals: 2.
 	
 	consumerInfoA := consumerInfoCol detect: [ :each | each name = consumerKeyA ] ifNone:[].
 	self assert: consumerInfoA pending equals: 0.
-	self assert: consumerInfoA idle > 100 equals: true.
-	self assert: consumerInfoA inactive > 100 equals: true.
+	self assert: consumerInfoA idle >= 100.
+	self assert: consumerInfoA inactive >= 100.
 	
 	consumerInfoB := consumerInfoCol detect: [ :each | each name = consumerKeyB ] ifNone:[].
 	self assert: consumerInfoB pending equals: 2.
-	self assert: consumerInfoB idle > 100 equals: true.
-	self assert: consumerInfoB inactive > 100 equals: true.
+	self assert: consumerInfoB idle >= 100.
+	self assert: consumerInfoB inactive >= 100.
 	
 	destroyedSize := stick endpoint xGroupDestroy: streamKey group: groupKey.
 	self assert: destroyedSize equals: 1.
@@ -493,7 +495,7 @@ RsRedisEndpointTest >> testXInfoStream [
 	ents2 := stick endpoint xGroupRead: streamKey id: '>' group: groupKey consumer: consumerKeyB count: 2.
 	
 	stick endpoint xAck: streamKey group: groupKey id: ents1 first id.
-	(Delay forMilliseconds: 100) wait.
+	(Delay forMilliseconds: 200) wait.
 	
 	streamInfo := stick endpoint xInfoStream: streamKey.
 	self assert: streamInfo size equals: 3.
@@ -533,7 +535,7 @@ RsRedisEndpointTest >> testXInfoStreamFull [
 	ents2 := stick endpoint xGroupRead: streamKey id: '>' group: groupKey consumer: consumerKeyB count: 2.
 	
 	stick endpoint xAck: streamKey group: groupKey id: ents1 first id.
-	(Delay forMilliseconds: 100) wait.
+	(Delay forMilliseconds: 200) wait.
 	
 	streamInfo := stick endpoint xInfoStream: streamKey full: true count: 2.
 	self assert: streamInfo size equals: 3.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI failures on `feature/redis-function` (Pharo64-12 / Pharo64-13) were caused by timing-sensitive stream tests that intermittently fail under CI load.

## Root cause

Several tests assumed fixed delays and strict timing boundaries that are not reliable on shared CI runners:

- `testXInfoConsumers` waited exactly 100ms, then asserted `idle > 100` and `inactive > 100` (zero margin)
- `testPollWithPendings` / `testPollWithPendingsAutoClaimed` assumed pollers would finish within a fixed 100ms wait
- `testXGroupClaim` / `testXGroupAutoClaim` used very small `minIdleTime` values (10ms) relative to surrounding waits

## Fix

- Increase XINFO consumer wait margin and use inclusive `>= 100` assertions
- Replace fixed poller delays with condition-based polling loops
- Increase XAUTOCLAIM/XCLAIM `minIdleTime` thresholds and XINFO stream wait times for more CI headroom

## Verification

- `smalltalkci -s Pharo64-11` — 321 tests passed
- `smalltalkci -s Pharo64-12` — 321 tests passed
- `smalltalkci -s Pharo64-13` — 321 tests passed
- Repeated Pharo64-13 runs: stream-related flakes no longer reproduced in 20 consecutive runs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53bd61fb-e38e-40ac-8418-76fef69e907a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53bd61fb-e38e-40ac-8418-76fef69e907a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

